### PR TITLE
Enable HMS logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ You can use the Hive Metastore for integration tests in your [Github Workflows](
           - 9083:9083
 ```
 
+## Logging
+
+By default the Hive Metastore will log at INFO level. You can override this by setting the `HMS_LOGLEVEL` environment variable for the container.
+
 ## Acknowledgements
 
 This image is based on [@naushadh](https://github.com/naushadh)'s [hive-metastore](https://github.com/naushadh/hive-metastore) repo.

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ set -euxo pipefail
 /opt/hive-metastore/bin/schematool --verbose -dbType derby -initSchema
 
 # start metastore (in foreground)
-/opt/hive-metastore/bin/hive --service metastore
+/opt/hive-metastore/bin/hive --service metastore --hiveconf hive.root.logger=INFO,console

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ set -euxo pipefail
 /opt/hive-metastore/bin/schematool --verbose -dbType derby -initSchema
 
 # start metastore (in foreground)
-/opt/hive-metastore/bin/hive --service metastore --hiveconf hive.root.logger=INFO,console
+/opt/hive-metastore/bin/hive --service metastore --hiveconf hive.root.logger=${HMS_LOGLEVEL:-INFO},console


### PR DESCRIPTION
The existing image does not write HMS log to stdout, which makes catching
and diagnosing problems more difficult.

This PR sets the level to INFO with an environment variable to override it
if required.

